### PR TITLE
windows and node 0.10 support (closes #4 and #8)

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,10 @@ function prompt(option) {
       option.echo = '*';
   }
 
-  var fd = fs.openSync('/dev/stdin', 'rs');
+  var fd = process.platform !== 'win32' && +process.version.substr(3) < 12 ? 
+    fs.openSync('/dev/tty', 'rs') : 
+    process.stdin.fd;
+    
   process.stdin.setRawMode(true);
   var buf = new Buffer(3);
   var str = '', char, read;


### PR DESCRIPTION
1. Windows has no /dev/stdin
2. process.stdin.fd however already contains the STDIN fd (`0`) on all platforms
3. `fs.readSync(process.stdin.fd, 'rs') ` works on Windows, on Node v0.10+
4. `fs.readSync(process.stdin.fd, 'rs') ` works on non-windows on Node 0.12+ (at least tested on OS X)
5. reading from /dev/stdin on v0.10 on non-windows fails also (at least on OS X)
6. reading from /dev/tty WORKS on 0.10 on non-windows

So, 

if v0.12+ OR windows we read from process.stdin.fd
if < 0.12 AND NOT windows we read from /dev/tty


Note: Edge case - will fail in REPL in windows (EBADF) 